### PR TITLE
지원서 제출 api 버그 수정

### DIFF
--- a/src/api/applications/application.entity.ts
+++ b/src/api/applications/application.entity.ts
@@ -21,7 +21,6 @@ type ApplicationForm = {
   thirdAnswer: string;
   fourthAnswer: string;
   fifthAnswer: string;
-  sixthAnswer: string;
 };
 
 @Entity('Application')
@@ -74,9 +73,6 @@ export class Application {
   @Column({ nullable: true })
   fifthAnswer: string;
 
-  @Column({ nullable: true })
-  sixthAnswer: string;
-
   @CreateDateColumn()
   createdDate: Date;
 
@@ -98,7 +94,6 @@ export class Application {
     thirdAnswer,
     fourthAnswer,
     fifthAnswer,
-    sixthAnswer,
   }: ApplicationForm): Application {
     const application = new Application();
 
@@ -117,7 +112,6 @@ export class Application {
     application.thirdAnswer = thirdAnswer;
     application.fourthAnswer = fourthAnswer;
     application.fifthAnswer = fifthAnswer;
-    application.sixthAnswer = sixthAnswer;
 
     return application;
   }

--- a/src/api/applications/applications.service.ts
+++ b/src/api/applications/applications.service.ts
@@ -1,5 +1,5 @@
 import { PutObjectCommand } from '@aws-sdk/client-s3';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, HttpException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
@@ -16,6 +16,27 @@ export class ApplicationsService {
 
   async create(createApplicationDto: CreateApplicationDto) {
     const { personalInfo, applicationInfo } = createApplicationDto;
+
+    // 디지몬 파트가 아닌데 자기소개서가 없으면 400 에러
+    if (personalInfo.part !== 'design') {
+      const errors: string[] = [];
+
+      if (!applicationInfo.cvUrl) {
+        errors.push(
+          "applicationInfo.cvUrl must be exist when personalInfo.part isn't design",
+        );
+      }
+
+      if (!applicationInfo.fifthAnswer) {
+        errors.push(
+          "applicationInfo.fifthAnswer must be exist when personalInfo.part isn't design",
+        );
+      }
+
+      if (errors.length > 0) {
+        throw new BadRequestException(errors);
+      }
+    }
 
     const application = Application.from({
       ...personalInfo,

--- a/src/api/applications/applications.service.ts
+++ b/src/api/applications/applications.service.ts
@@ -52,7 +52,7 @@ export class ApplicationsService {
       throw new ConflictException(conflictErrors);
     }
 
-    // 디지몬 파트가 아닌데 자기소개서가 없으면 400 에러
+    // 디지몬 파트가 아닌데 자기소개서 페이지 파일이 없으면 400 에러
     if (personalInfo.part !== 'design') {
       const errors: string[] = [];
 

--- a/src/api/applications/applications.service.ts
+++ b/src/api/applications/applications.service.ts
@@ -1,5 +1,9 @@
 import { PutObjectCommand } from '@aws-sdk/client-s3';
-import { BadRequestException, HttpException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
@@ -16,6 +20,31 @@ export class ApplicationsService {
 
   async create(createApplicationDto: CreateApplicationDto) {
     const { personalInfo, applicationInfo } = createApplicationDto;
+
+    const conflictErrors: string[] = [];
+    const [samePhoneUser] = await this.applicationRepository.findBy({
+      phone: personalInfo.phone,
+    });
+    const [sameEmailUser] = await this.applicationRepository.findBy({
+      email: personalInfo.email,
+    });
+    const [sameSidUser] = await this.applicationRepository.findBy({
+      sid: personalInfo.sid,
+    });
+
+    if (samePhoneUser) {
+      conflictErrors.push(`phone ${personalInfo.phone} is already exist`);
+    }
+    if (sameEmailUser) {
+      conflictErrors.push(`email ${personalInfo.email} is already exist`);
+    }
+    if (sameSidUser) {
+      conflictErrors.push(`sid ${personalInfo.sid} is already exist`);
+    }
+
+    if (conflictErrors.length > 0) {
+      throw new ConflictException(conflictErrors);
+    }
 
     // 디지몬 파트가 아닌데 자기소개서가 없으면 400 에러
     if (personalInfo.part !== 'design') {

--- a/src/api/applications/applications.service.ts
+++ b/src/api/applications/applications.service.ts
@@ -22,14 +22,20 @@ export class ApplicationsService {
     const { personalInfo, applicationInfo } = createApplicationDto;
 
     const conflictErrors: string[] = [];
-    const [samePhoneUser] = await this.applicationRepository.findBy({
-      phone: personalInfo.phone,
+    const samePhoneUser = await this.applicationRepository.findOne({
+      where: {
+        phone: personalInfo.phone,
+      },
     });
-    const [sameEmailUser] = await this.applicationRepository.findBy({
-      email: personalInfo.email,
+    const sameEmailUser = await this.applicationRepository.findOne({
+      where: {
+        email: personalInfo.email,
+      },
     });
-    const [sameSidUser] = await this.applicationRepository.findBy({
-      sid: personalInfo.sid,
+    const sameSidUser = await this.applicationRepository.findOne({
+      where: {
+        sid: personalInfo.sid,
+      },
     });
 
     if (samePhoneUser) {

--- a/src/api/applications/dto/create-application.dto.ts
+++ b/src/api/applications/dto/create-application.dto.ts
@@ -86,9 +86,6 @@ class PersonalInfo {
   readonly personalInfoAgreement: true;
 }
 
-/**
- * 문항은 최대 6개일 것이라고 가정
- */
 class ApplicationInfo {
   @ApiProperty({
     example: 'https://example.com/cv.zip',
@@ -137,14 +134,6 @@ class ApplicationInfo {
   @IsString()
   @MaxLength(1000)
   readonly fifthAnswer: string;
-
-  @ApiProperty({
-    example: '여섯 번째 문항 답변입니다.',
-    description: '여섯 번째 문항 답변 (1000자 이하)',
-  })
-  @IsString()
-  @MaxLength(1000)
-  readonly sixthAnswer: string;
 }
 
 export class CreateApplicationDto {

--- a/src/api/applications/dto/create-application.dto.ts
+++ b/src/api/applications/dto/create-application.dto.ts
@@ -5,6 +5,7 @@ import {
   IsEmail,
   IsIn,
   IsObject,
+  IsOptional,
   IsString,
   IsUrl,
   Matches,
@@ -91,6 +92,7 @@ class ApplicationInfo {
     example: 'https://example.com/cv.zip',
     description: '자기소개서 링크 (URL)',
   })
+  @IsOptional()
   @IsUrl()
   @MaxLength(512)
   readonly cvUrl: string;
@@ -131,6 +133,8 @@ class ApplicationInfo {
     example: '다섯 번째 문항 답변입니다.',
     description: '다섯 번째 문항 답변 (1000자 이하)',
   })
+  // 디지몬 파트는 다섯 번째 문항이 없으므로 Optional
+  @IsOptional()
   @IsString()
   @MaxLength(1000)
   readonly fifthAnswer: string;


### PR DESCRIPTION
## 작업 내용

- 디지몬 파트는 자기소개서 url 을 제출하지 않아도 되도록 바꿨습니다.
- 6번 문항을 사용하는 파트가 없어 삭제시켰습니다.
- 디지몬 파트는 5번 문항을 제출하지 않아도 되도록 바꿨습니다.
- 중복 지원 시 500 에러가 터지던 것을 409 에러로 바꿨습니다.

## 리뷰 시 주의사항

- 작업 끝났습니당 한 방에 리뷰해주세여